### PR TITLE
Make it possible to override the SessionManager creation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
@@ -70,7 +70,7 @@ open class RequestBuilder<T> {
     }
 }
 
-protocol RequestBuilderFactory {
+public protocol RequestBuilderFactory {
     func getBuilder<T>() -> RequestBuilder<T>.Type
 }
 

--- a/modules/swagger-codegen/src/main/resources/swift/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/AlamofireImplementations.mustache
@@ -15,17 +15,25 @@ class AlamofireRequestBuilderFactory: RequestBuilderFactory {
 // Store manager to retain its reference
 private var managerStore: [String: Alamofire.SessionManager] = [:]
 
-class AlamofireRequestBuilder<T>: RequestBuilder<T> {
-    required init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool) {
+open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
+    required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool) {
         super.init(method: method, URLString: URLString, parameters: parameters, isBody: isBody)
     }
 
-    override func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
-        let managerId:String = UUID().uuidString
-        // Create a new manager for each request to customize its request header
+    /**
+     May be overridden by a subclass if you want to control the session
+     configuration.
+     */
+    open func createSessionManager() -> Alamofire.SessionManager {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = buildHeaders()
-        let manager = Alamofire.SessionManager(configuration: configuration)
+        return Alamofire.SessionManager(configuration: configuration)
+    }
+
+    override open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
+        let managerId:String = UUID().uuidString
+        // Create a new manager for each request to customize its request header
+        let manager = createSessionManager()
         managerStore[managerId] = manager
 
         let encoding:ParameterEncoding = isBody ? JSONEncoding() : URLEncoding()

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -70,7 +70,7 @@ open class RequestBuilder<T> {
     }
 }
 
-protocol RequestBuilderFactory {
+public protocol RequestBuilderFactory {
     func getBuilder<T>() -> RequestBuilder<T>.Type
 }
 

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -15,17 +15,25 @@ class AlamofireRequestBuilderFactory: RequestBuilderFactory {
 // Store manager to retain its reference
 private var managerStore: [String: Alamofire.SessionManager] = [:]
 
-class AlamofireRequestBuilder<T>: RequestBuilder<T> {
-    required init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool) {
+open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
+    required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool) {
         super.init(method: method, URLString: URLString, parameters: parameters, isBody: isBody)
     }
 
-    override func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
-        let managerId:String = UUID().uuidString
-        // Create a new manager for each request to customize its request header
+    /**
+     May be overridden by a subclass if you want to control the session
+     configuration.
+     */
+    open func createSessionManager() -> Alamofire.SessionManager {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = buildHeaders()
-        let manager = Alamofire.SessionManager(configuration: configuration)
+        return Alamofire.SessionManager(configuration: configuration)
+    }
+
+    override open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
+        let managerId:String = UUID().uuidString
+        // Create a new manager for each request to customize its request header
+        let manager = createSessionManager()
         managerStore[managerId] = manager
 
         let encoding:ParameterEncoding = isBody ? JSONEncoding() : URLEncoding()

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -70,7 +70,7 @@ open class RequestBuilder<T> {
     }
 }
 
-protocol RequestBuilderFactory {
+public protocol RequestBuilderFactory {
     func getBuilder<T>() -> RequestBuilder<T>.Type
 }
 

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -15,17 +15,25 @@ class AlamofireRequestBuilderFactory: RequestBuilderFactory {
 // Store manager to retain its reference
 private var managerStore: [String: Alamofire.SessionManager] = [:]
 
-class AlamofireRequestBuilder<T>: RequestBuilder<T> {
-    required init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool) {
+open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
+    required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool) {
         super.init(method: method, URLString: URLString, parameters: parameters, isBody: isBody)
     }
 
-    override func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
-        let managerId:String = UUID().uuidString
-        // Create a new manager for each request to customize its request header
+    /**
+     May be overridden by a subclass if you want to control the session
+     configuration.
+     */
+    open func createSessionManager() -> Alamofire.SessionManager {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = buildHeaders()
-        let manager = Alamofire.SessionManager(configuration: configuration)
+        return Alamofire.SessionManager(configuration: configuration)
+    }
+
+    override open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
+        let managerId:String = UUID().uuidString
+        // Create a new manager for each request to customize its request header
+        let manager = createSessionManager()
         managerStore[managerId] = manager
 
         let encoding:ParameterEncoding = isBody ? JSONEncoding() : URLEncoding()

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -70,7 +70,7 @@ open class RequestBuilder<T> {
     }
 }
 
-protocol RequestBuilderFactory {
+public protocol RequestBuilderFactory {
     func getBuilder<T>() -> RequestBuilder<T>.Type
 }
 

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -15,17 +15,25 @@ class AlamofireRequestBuilderFactory: RequestBuilderFactory {
 // Store manager to retain its reference
 private var managerStore: [String: Alamofire.SessionManager] = [:]
 
-class AlamofireRequestBuilder<T>: RequestBuilder<T> {
-    required init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool) {
+open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
+    required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool) {
         super.init(method: method, URLString: URLString, parameters: parameters, isBody: isBody)
     }
 
-    override func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
-        let managerId:String = UUID().uuidString
-        // Create a new manager for each request to customize its request header
+    /**
+     May be overridden by a subclass if you want to control the session
+     configuration.
+     */
+    open func createSessionManager() -> Alamofire.SessionManager {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = buildHeaders()
-        let manager = Alamofire.SessionManager(configuration: configuration)
+        return Alamofire.SessionManager(configuration: configuration)
+    }
+
+    override open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
+        let managerId:String = UUID().uuidString
+        // Create a new manager for each request to customize its request header
+        let manager = createSessionManager()
         managerStore[managerId] = manager
 
         let encoding:ParameterEncoding = isBody ? JSONEncoding() : URLEncoding()


### PR DESCRIPTION
This exposes RequestBuilderFactory and AlamofireRequestBuilder, and breaks the SessionManager creation out into a separate function called createSessionManager.  Together, these changes make it possible to inherit all the behavior of AlamofireRequestBuilder, but replace the SessionManager creation.
