### PR TITLE
Fix handling of arrays in Swift generator

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -145,6 +145,11 @@ class Decoders {
         }
         // Decoder for {{{classname}}}
         Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject) -> {{{classname}}} in
+{{#isArrayModel}}
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: {{{arrayModelType}}}.self, source: $0) })
+{{/isArrayModel}}
+{{^isArrayModel}}
             let sourceDictionary = source as! [AnyHashable: Any]
             {{#unwrapRequired}}
             let instance = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{#isEnum}}{{name}}: {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{baseName}}"] as! {{datatype}}))! {{/isEnum}}{{^isEnum}}{{name}}: Decoders.decode(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"]! as AnyObject){{/isEnum}}{{/requiredVars}})
@@ -165,6 +170,7 @@ class Decoders {
             {{^isEnum}}instance.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}{{/vars}}
             {{/unwrapRequired}}
             return instance
+{{/isArrayModel}}
         }{{/model}}
         {{/models}}
     }()

--- a/modules/swagger-codegen/src/main/resources/swift/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/model.mustache
@@ -10,6 +10,10 @@ import Foundation
 {{#description}}
 
 /** {{description}} */{{/description}}
+{{#isArrayModel}}
+public typealias {{classname}} = [{{arrayModelType}}]
+{{/isArrayModel}}
+{{^isArrayModel}}
 open class {{classname}}: JSONEncodable {
 {{#vars}}
 {{#isEnum}}
@@ -57,5 +61,7 @@ open class {{classname}}: JSONEncodable {
         return dictionary
 {{/vars.isEmpty}}
     }
-}{{/model}}
+}
+{{/isArrayModel}}
+{{/model}}
 {{/models}}

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,9 +173,8 @@ class Decoders {
         }
         // Decoder for AnimalFarm
         Decoders.addDecoder(clazz: AnimalFarm.self) { (source: AnyObject) -> AnimalFarm in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = AnimalFarm()
-            return instance
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: Animal.self, source: $0) })
         }
 
 

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class AnimalFarm: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,9 +173,8 @@ class Decoders {
         }
         // Decoder for AnimalFarm
         Decoders.addDecoder(clazz: AnimalFarm.self) { (source: AnyObject) -> AnimalFarm in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = AnimalFarm()
-            return instance
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: Animal.self, source: $0) })
         }
 
 

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class AnimalFarm: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,9 +173,8 @@ class Decoders {
         }
         // Decoder for AnimalFarm
         Decoders.addDecoder(clazz: AnimalFarm.self) { (source: AnyObject) -> AnimalFarm in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = AnimalFarm()
-            return instance
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: Animal.self, source: $0) })
         }
 
 

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class AnimalFarm: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias AnimalFarm = [Animal]


### PR DESCRIPTION
Change modeling so that a Swagger array is represented as a typealias in Swift.

This means that a declaration like `"Foos": { "type": "array", "items": { "$ref": "#/definitions/Foo" } }` will generate a `typealias Foos = [Foo]` in the model file, and a decoder that takes the array in the response and decodes each element individually.
