### PR TITLE
Fix the generation of Swift code for defined type aliases.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1302,13 +1302,15 @@ public class DefaultCodegen {
             addVars(m, properties, required, allProperties, allRequired);
         } else {
             ModelImpl impl = (ModelImpl) model;
+            if (m != null && impl.getType() != null) {
+                Property p = PropertyBuilder.build(impl.getType(), impl.getFormat(), null);
+                m.dataType = getSwaggerType(p);
+            }
             if(impl.getEnum() != null && impl.getEnum().size() > 0) {
                 m.isEnum = true;
                 // comment out below as allowableValues is not set in post processing model enum
                 m.allowableValues = new HashMap<String, Object>();
                 m.allowableValues.put("values", impl.getEnum());
-                Property p = PropertyBuilder.build(impl.getType(), impl.getFormat(), null);
-                m.dataType = getSwaggerType(p);
             }
             if (impl.getAdditionalProperties() != null) {
                 addAdditionPropertiesToCodeGenModel(m, impl);

--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -150,6 +150,13 @@ class Decoders {
             return sourceArray.map({ Decoders.decode(clazz: {{{arrayModelType}}}.self, source: $0) })
 {{/isArrayModel}}
 {{^isArrayModel}}
+{{#vars.isEmpty}}
+            if let source = source as? {{dataType}} {
+                return source
+            }
+            fatalError("Source \(source) is not convertible to typealias {{classname}}: Maybe swagger file is insufficient")
+{{/vars.isEmpty}}
+{{^vars.isEmpty}}
             let sourceDictionary = source as! [AnyHashable: Any]
             {{#unwrapRequired}}
             let instance = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{#isEnum}}{{name}}: {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{baseName}}"] as! {{datatype}}))! {{/isEnum}}{{^isEnum}}{{name}}: Decoders.decode(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"]! as AnyObject){{/isEnum}}{{/requiredVars}})
@@ -170,6 +177,7 @@ class Decoders {
             {{^isEnum}}instance.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}{{/vars}}
             {{/unwrapRequired}}
             return instance
+{{/vars.isEmpty}}
 {{/isArrayModel}}
         }{{/model}}
         {{/models}}

--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -145,6 +145,11 @@ class Decoders {
         }
         // Decoder for {{{classname}}}
         Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject) -> {{{classname}}} in
+{{#isArrayModel}}
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: {{{arrayModelType}}}.self, source: $0) })
+{{/isArrayModel}}
+{{^isArrayModel}}
             let sourceDictionary = source as! [AnyHashable: Any]
             {{#unwrapRequired}}
             let instance = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{#isEnum}}{{name}}: {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{baseName}}"] as! {{datatype}}))! {{/isEnum}}{{^isEnum}}{{name}}: Decoders.decode(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"]! as AnyObject){{/isEnum}}{{/requiredVars}})
@@ -165,6 +170,7 @@ class Decoders {
             {{^isEnum}}instance.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}{{/vars}}
             {{/unwrapRequired}}
             return instance
+{{/isArrayModel}}
         }{{/model}}
         {{/models}}
     }()

--- a/modules/swagger-codegen/src/main/resources/swift/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/model.mustache
@@ -10,6 +10,10 @@ import Foundation
 {{#description}}
 
 /** {{description}} */{{/description}}
+{{#isArrayModel}}
+public typealias {{classname}} = [{{arrayModelType}}]
+{{/isArrayModel}}
+{{^isArrayModel}}
 open class {{classname}}: JSONEncodable {
 {{#vars}}
 {{#isEnum}}
@@ -57,5 +61,7 @@ open class {{classname}}: JSONEncodable {
         return dictionary
 {{/vars.isEmpty}}
     }
-}{{/model}}
+}
+{{/isArrayModel}}
+{{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/swift/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/model.mustache
@@ -14,6 +14,10 @@ import Foundation
 public typealias {{classname}} = [{{arrayModelType}}]
 {{/isArrayModel}}
 {{^isArrayModel}}
+{{#vars.isEmpty}}
+public typealias {{classname}} = {{dataType}}
+{{/vars.isEmpty}}
+{{^vars.isEmpty}}
 open class {{classname}}: JSONEncodable {
 {{#vars}}
 {{#isEnum}}
@@ -46,10 +50,6 @@ open class {{classname}}: JSONEncodable {
 
     // MARK: JSONEncodable
     func encodeToJSON() -> Any {
-{{#vars.isEmpty}}
-        return [:]
-{{/vars.isEmpty}}
-{{^vars.isEmpty}}
         var nillableDictionary = [String:Any?](){{#vars}}{{#isNotContainer}}{{#isPrimitiveType}}{{^isEnum}}{{#isInteger}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isInteger}}{{#isLong}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isLong}}{{^isLong}}{{^isInteger}}
@@ -59,9 +59,9 @@ open class {{classname}}: JSONEncodable {
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isContainer}}{{/vars}}
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
-{{/vars.isEmpty}}
     }
 }
+{{/vars.isEmpty}}
 {{/isArrayModel}}
 {{/model}}
 {{/models}}

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,9 +173,8 @@ class Decoders {
         }
         // Decoder for AnimalFarm
         Decoders.addDecoder(clazz: AnimalFarm.self) { (source: AnyObject) -> AnimalFarm in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = AnimalFarm()
-            return instance
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: Animal.self, source: $0) })
         }
 
 

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -317,9 +317,10 @@ class Decoders {
         }
         // Decoder for EnumClass
         Decoders.addDecoder(clazz: EnumClass.self) { (source: AnyObject) -> EnumClass in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = EnumClass()
-            return instance
+            if let source = source as? String {
+                return source
+            }
+            fatalError("Source \(source) is not convertible to typealias EnumClass: Maybe swagger file is insufficient")
         }
 
 

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class AnimalFarm: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class EnumClass: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias EnumClass = String

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,9 +173,8 @@ class Decoders {
         }
         // Decoder for AnimalFarm
         Decoders.addDecoder(clazz: AnimalFarm.self) { (source: AnyObject) -> AnimalFarm in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = AnimalFarm()
-            return instance
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: Animal.self, source: $0) })
         }
 
 

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -317,9 +317,10 @@ class Decoders {
         }
         // Decoder for EnumClass
         Decoders.addDecoder(clazz: EnumClass.self) { (source: AnyObject) -> EnumClass in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = EnumClass()
-            return instance
+            if let source = source as? String {
+                return source
+            }
+            fatalError("Source \(source) is not convertible to typealias EnumClass: Maybe swagger file is insufficient")
         }
 
 

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class AnimalFarm: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class EnumClass: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias EnumClass = String

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,9 +173,8 @@ class Decoders {
         }
         // Decoder for AnimalFarm
         Decoders.addDecoder(clazz: AnimalFarm.self) { (source: AnyObject) -> AnimalFarm in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = AnimalFarm()
-            return instance
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: Animal.self, source: $0) })
         }
 
 

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -317,9 +317,10 @@ class Decoders {
         }
         // Decoder for EnumClass
         Decoders.addDecoder(clazz: EnumClass.self) { (source: AnyObject) -> EnumClass in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = EnumClass()
-            return instance
+            if let source = source as? String {
+                return source
+            }
+            fatalError("Source \(source) is not convertible to typealias EnumClass: Maybe swagger file is insufficient")
         }
 
 

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class AnimalFarm: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class EnumClass: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias EnumClass = String


### PR DESCRIPTION
In a declaration like `"Foo": { "type": "number", "format": "double" }`, where there is not a "properties" entry in that declaration, the type Foo is simply an alias for Double.  These were previously being generated in Swift as an empty class, but then they wouldn't decode because on the wire there would be a number, not a dictionary.

Fix this by generating a typealias declaration in this situation.

This PR applies on top of #4.
