### PR TITLE
    Handle enums when they are declared as definitions.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1302,13 +1302,15 @@ public class DefaultCodegen {
             addVars(m, properties, required, allProperties, allRequired);
         } else {
             ModelImpl impl = (ModelImpl) model;
+            if (m != null && impl.getType() != null) {
+                Property p = PropertyBuilder.build(impl.getType(), impl.getFormat(), null);
+                m.dataType = getSwaggerType(p);
+            }
             if(impl.getEnum() != null && impl.getEnum().size() > 0) {
                 m.isEnum = true;
                 // comment out below as allowableValues is not set in post processing model enum
                 m.allowableValues = new HashMap<String, Object>();
                 m.allowableValues.put("values", impl.getEnum());
-                Property p = PropertyBuilder.build(impl.getType(), impl.getFormat(), null);
-                m.dataType = getSwaggerType(p);
             }
             if (impl.getAdditionalProperties() != null) {
                 addAdditionPropertiesToCodeGenModel(m, impl);

--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -150,6 +150,13 @@ class Decoders {
             return sourceArray.map({ Decoders.decode(clazz: {{{arrayModelType}}}.self, source: $0) })
 {{/isArrayModel}}
 {{^isArrayModel}}
+{{#vars.isEmpty}}
+            if let source = source as? {{dataType}} {
+                return source
+            }
+            fatalError("Source \(source) is not convertible to typealias {{classname}}: Maybe swagger file is insufficient")
+{{/vars.isEmpty}}
+{{^vars.isEmpty}}
             let sourceDictionary = source as! [AnyHashable: Any]
             {{#unwrapRequired}}
             let instance = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{#isEnum}}{{name}}: {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{baseName}}"] as! {{datatype}}))! {{/isEnum}}{{^isEnum}}{{name}}: Decoders.decode(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"]! as AnyObject){{/isEnum}}{{/requiredVars}})
@@ -170,6 +177,7 @@ class Decoders {
             {{^isEnum}}instance.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}{{/vars}}
             {{/unwrapRequired}}
             return instance
+{{/vars.isEmpty}}
 {{/isArrayModel}}
         }{{/model}}
         {{/models}}

--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -150,6 +150,15 @@ class Decoders {
             return sourceArray.map({ Decoders.decode(clazz: {{{arrayModelType}}}.self, source: $0) })
 {{/isArrayModel}}
 {{^isArrayModel}}
+{{#isEnum}}
+            if let source = source as? {{dataType}} {
+                if let result = {{classname}}(rawValue: source) {
+                    return result
+                }
+            }
+            fatalError("Source \(source) is not convertible to enum type {{classname}}: Maybe swagger file is insufficient")
+{{/isEnum}}
+{{^isEnum}}
 {{#vars.isEmpty}}
             if let source = source as? {{dataType}} {
                 return source
@@ -178,6 +187,7 @@ class Decoders {
             {{/unwrapRequired}}
             return instance
 {{/vars.isEmpty}}
+{{/isEnum}}
 {{/isArrayModel}}
         }{{/model}}
         {{/models}}

--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -145,6 +145,11 @@ class Decoders {
         }
         // Decoder for {{{classname}}}
         Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject) -> {{{classname}}} in
+{{#isArrayModel}}
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: {{{arrayModelType}}}.self, source: $0) })
+{{/isArrayModel}}
+{{^isArrayModel}}
             let sourceDictionary = source as! [AnyHashable: Any]
             {{#unwrapRequired}}
             let instance = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{#isEnum}}{{name}}: {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{baseName}}"] as! {{datatype}}))! {{/isEnum}}{{^isEnum}}{{name}}: Decoders.decode(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"]! as AnyObject){{/isEnum}}{{/requiredVars}})
@@ -165,6 +170,7 @@ class Decoders {
             {{^isEnum}}instance.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}{{/vars}}
             {{/unwrapRequired}}
             return instance
+{{/isArrayModel}}
         }{{/model}}
         {{/models}}
     }()

--- a/modules/swagger-codegen/src/main/resources/swift/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/model.mustache
@@ -10,6 +10,10 @@ import Foundation
 {{#description}}
 
 /** {{description}} */{{/description}}
+{{#isArrayModel}}
+public typealias {{classname}} = [{{arrayModelType}}]
+{{/isArrayModel}}
+{{^isArrayModel}}
 open class {{classname}}: JSONEncodable {
 {{#vars}}
 {{#isEnum}}
@@ -57,5 +61,7 @@ open class {{classname}}: JSONEncodable {
         return dictionary
 {{/vars.isEmpty}}
     }
-}{{/model}}
+}
+{{/isArrayModel}}
+{{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/swift/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/model.mustache
@@ -14,6 +14,14 @@ import Foundation
 public typealias {{classname}} = [{{arrayModelType}}]
 {{/isArrayModel}}
 {{^isArrayModel}}
+{{#isEnum}}
+public enum {{classname}}: {{dataType}} {
+{{#allowableValues}}{{#enumVars}}    case {{name}} = "{{{value}}}"
+{{/enumVars}}{{/allowableValues}}
+    func encodeToJSON() -> Any { return self.rawValue }
+}
+{{/isEnum}}
+{{^isEnum}}
 {{#vars.isEmpty}}
 public typealias {{classname}} = {{dataType}}
 {{/vars.isEmpty}}
@@ -62,6 +70,7 @@ open class {{classname}}: JSONEncodable {
     }
 }
 {{/vars.isEmpty}}
+{{/isEnum}}
 {{/isArrayModel}}
 {{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/swift/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/model.mustache
@@ -14,6 +14,10 @@ import Foundation
 public typealias {{classname}} = [{{arrayModelType}}]
 {{/isArrayModel}}
 {{^isArrayModel}}
+{{#vars.isEmpty}}
+public typealias {{classname}} = {{dataType}}
+{{/vars.isEmpty}}
+{{^vars.isEmpty}}
 open class {{classname}}: JSONEncodable {
 {{#vars}}
 {{#isEnum}}
@@ -46,10 +50,6 @@ open class {{classname}}: JSONEncodable {
 
     // MARK: JSONEncodable
     func encodeToJSON() -> Any {
-{{#vars.isEmpty}}
-        return [:]
-{{/vars.isEmpty}}
-{{^vars.isEmpty}}
         var nillableDictionary = [String:Any?](){{#vars}}{{#isNotContainer}}{{#isPrimitiveType}}{{^isEnum}}{{#isInteger}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isInteger}}{{#isLong}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isLong}}{{^isLong}}{{^isInteger}}
@@ -59,9 +59,9 @@ open class {{classname}}: JSONEncodable {
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isContainer}}{{/vars}}
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
-{{/vars.isEmpty}}
     }
 }
+{{/vars.isEmpty}}
 {{/isArrayModel}}
 {{/model}}
 {{/models}}

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,9 +173,8 @@ class Decoders {
         }
         // Decoder for AnimalFarm
         Decoders.addDecoder(clazz: AnimalFarm.self) { (source: AnyObject) -> AnimalFarm in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = AnimalFarm()
-            return instance
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: Animal.self, source: $0) })
         }
 
 

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -317,9 +317,10 @@ class Decoders {
         }
         // Decoder for EnumClass
         Decoders.addDecoder(clazz: EnumClass.self) { (source: AnyObject) -> EnumClass in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = EnumClass()
-            return instance
+            if let source = source as? String {
+                return source
+            }
+            fatalError("Source \(source) is not convertible to typealias EnumClass: Maybe swagger file is insufficient")
         }
 
 

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class AnimalFarm: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class EnumClass: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias EnumClass = String

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,9 +173,8 @@ class Decoders {
         }
         // Decoder for AnimalFarm
         Decoders.addDecoder(clazz: AnimalFarm.self) { (source: AnyObject) -> AnimalFarm in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = AnimalFarm()
-            return instance
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: Animal.self, source: $0) })
         }
 
 

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -317,9 +317,10 @@ class Decoders {
         }
         // Decoder for EnumClass
         Decoders.addDecoder(clazz: EnumClass.self) { (source: AnyObject) -> EnumClass in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = EnumClass()
-            return instance
+            if let source = source as? String {
+                return source
+            }
+            fatalError("Source \(source) is not convertible to typealias EnumClass: Maybe swagger file is insufficient")
         }
 
 

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class AnimalFarm: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class EnumClass: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias EnumClass = String

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,9 +173,8 @@ class Decoders {
         }
         // Decoder for AnimalFarm
         Decoders.addDecoder(clazz: AnimalFarm.self) { (source: AnyObject) -> AnimalFarm in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = AnimalFarm()
-            return instance
+            let sourceArray = source as! [AnyObject]
+            return sourceArray.map({ Decoders.decode(clazz: Animal.self, source: $0) })
         }
 
 

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -317,9 +317,10 @@ class Decoders {
         }
         // Decoder for EnumClass
         Decoders.addDecoder(clazz: EnumClass.self) { (source: AnyObject) -> EnumClass in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let instance = EnumClass()
-            return instance
+            if let source = source as? String {
+                return source
+            }
+            fatalError("Source \(source) is not convertible to typealias EnumClass: Maybe swagger file is insufficient")
         }
 
 

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/AnimalFarm.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class AnimalFarm: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumClass.swift
@@ -8,12 +8,4 @@
 import Foundation
 
 
-open class EnumClass: JSONEncodable {
-
-    public init() {}
-
-    // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        return [:]
-    }
-}
+public typealias EnumClass = String


### PR DESCRIPTION
These appear at the top level of the template (as opposed to as a property of another class).  Handle these with an enum declaration and a matching decoder.

Note that decode failure is treated as a fatalError, which I'm not a fan of, but which matches the rest of the Decoder interface.

Note also that this puts the enum value in double-quotes, assuming that it is a string on the wire.  I'm pretty sure that this isn't going to work for cases where enums are declared as some other type, but I don't know how to fix this yet.

This applies on top of #5 .
